### PR TITLE
Implement workaround for JRASERVER-34746

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ This Splunk Technical Add-on enables you to index Jira issues by querying your J
 
 - this JQL query string matches all issues in the service desk (SD) project that have been updated during the last 15 minutes
 
-## Why you should not use Jira Issues Collector Add-on
-
-The Add-on [Jira Issues Collector](https://splunkbase.splunk.com/app/4814/) does not support API pagination. That means if your JQL query string returns more than the maximum allowable value defined by the Jira property `jira.search.views.default.max`, which defaults to `100`, you will loose data.
-
-This TA supports API pagination and adds some additional functionalities!
-
 ## Configuration
 
 1. Setup the Jira Account by going to the configuration page of the TA-jira_issue_input app: **Configuration** -> **Account**
@@ -35,6 +29,10 @@ This TA supports API pagination and adds some additional functionalities!
 - **JQL (Jira Query Language)** | The JQL query string defines which issues to collect
 - **Issue Fields** | Comma-separated list of Jira issue fields to collect. This config option also supports wildcards like \*all. More infos can be found [here](https://docs.atlassian.com/software/jira/docs/api/REST/latest/#search-search).
 - **Expand Fields** | *(optional)* Comma-separated list of entities to expand. More infos can be found [here](https://docs.atlassian.com/software/jira/docs/api/REST/latest/).
+
+## Additional Notes
+
+This TA includes a workaround for [JRASERVER-34746](https://jira.atlassian.com/browse/JRASERVER-34746), which means you can use the `worklog` field to fetch all worklogs.
 
 ## How to dev
 

--- a/TA-jira_issue_input/bin/jira_issue.py
+++ b/TA-jira_issue_input/bin/jira_issue.py
@@ -57,7 +57,8 @@ class ModInputjira_issue(modinput_wrapper.base_modinput.BaseModInput):
                 description=(
                     "The JQL (Jira Query Language) search filter defines which Jira issues to"
                     " collect (more infos:"
-                    " https://docs.atlassian.com/software/jira/docs/api/REST/8.13.12/#search-search)"
+                    " https://docs.atlassian.com/software/jira/docs/api/REST/8.13.12/"
+                    "#search-search)"
                 ),
                 required_on_create=True,
                 required_on_edit=False,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       SPLUNK_PASSWORD: secret123
       SPLUNK_ROLE: splunk_standalone
       SPLUNK_LICENSE_URI: /tmp/splunk.lic
-      SPLUNK_APPS_URL: https://splunkbase.splunk.com/app/2962/release/4.0.0/download
+      SPLUNK_APPS_URL: https://splunkbase.splunk.com/app/2962/release/4.1.2/download
     env_file:
       - splunkbase.credentials
     ports:


### PR DESCRIPTION
The Jira REST API has a bug that does not return all worklogs if you specify the worklog field in the search/issue endpoint ([JRASERVER-34746](https://jira.atlassian.com/browse/JRASERVER-34746)).

This PR implements a workaround for this issue.